### PR TITLE
Fix commons site deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1782,7 +1782,7 @@
     <!-- value modules can override it -->
     <commons.site.path>${commons.componentid}</commons.site.path>
 
-    <commons.scmPubUrl>https://svn.apache.org/repos/infra/websites/production/commons/content/proper/${project.artifactId}</commons.scmPubUrl>
+    <commons.scmPubUrl>https://svn.apache.org/repos/infra/websites/production/commons/content/proper/commons-${project.artifactId}</commons.scmPubUrl>
     <commons.scmPubCheckoutDirectory>${commons.site.cache}/${commons.site.path}</commons.scmPubCheckoutDirectory>
     <commons.scmPubServer>commons.site</commons.scmPubServer>
     


### PR DESCRIPTION
The value of commons.scmPubUrl evaluated for example for Commons IO to

  .../commons/content/proper/io

Because the project.artifactId is always only the component name without
the 'commons-' prefix. This change adds the 'commons-' prefix before the
project.artifactId.