### PR TITLE
add JAVA_1_10_HOME,JAVA_1_11_HOME,JAVA_1_12_HOME into _removeheaders in maven-bundle-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -627,7 +627,7 @@
             <!-- stops the "uses" clauses being added to "Export-Package" manifest entry -->
             <_nouses>true</_nouses>
             <!-- Stop the JAVA_1_n_HOME variables from being treated as headers by Bnd -->
-            <_removeheaders>JAVA_1_3_HOME,JAVA_1_4_HOME,JAVA_1_5_HOME,JAVA_1_6_HOME,JAVA_1_7_HOME,JAVA_1_8_HOME,JAVA_1_9_HOME</_removeheaders>
+            <_removeheaders>JAVA_1_3_HOME,JAVA_1_4_HOME,JAVA_1_5_HOME,JAVA_1_6_HOME,JAVA_1_7_HOME,JAVA_1_8_HOME,JAVA_1_9_HOME,JAVA_1_10_HOME,JAVA_1_11_HOME,JAVA_1_12_HOME</_removeheaders>
             <Bundle-SymbolicName>${commons.osgi.symbolicName}</Bundle-SymbolicName>
             <Export-Package>${commons.osgi.export}</Export-Package>
             <Private-Package>${commons.osgi.private}</Private-Package>


### PR DESCRIPTION
Is there any reasons for them not being in that list?
If not, then I think we shall add them for compliance with this line:
```
    <!-- N.B. when adding new java profiles, be sure to update
      the _removeheaders list in the maven_bundle_plugin configuration -->
```
Otherwise, please modify the line above.
Thanks.