### PR TITLE
move maven-javadoc-plugin to <build>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -952,7 +952,22 @@
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>create-javadoc-jar</id>
+            <goals>
+              <goal>javadoc</goal>
+              <goal>jar</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-publish-plugin</artifactId>
@@ -1451,22 +1466,6 @@
             <configuration>
               <!-- Pass these arguments to the deploy plugin. -->
               <arguments>-Prelease</arguments>
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>create-javadoc-jar</id>
-                <goals>
-                  <goal>javadoc</goal>
-                  <goal>jar</goal>
-                </goals>
-                <phase>package</phase>
-              </execution>
-            </executions>
-            <configuration>
-              <source>${maven.compiler.source}</source>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
move maven-javadoc-plugin from <report> to <build>.
As quite some of (if not most of) commons projects have javadoc error, minor ones or major ones. 
I think it is better to let people know if they makes javadoc uncorrectly when they create/change javadoc, but not when release.