### PR TITLE
Improve reproducibility of generated JARs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -898,8 +898,20 @@
           <instructions>
             <!-- stops the "uses" clauses being added to "Export-Package" manifest entry -->
             <_nouses>true</_nouses>
-            <!-- Stop the JAVA_1_n_HOME variables from being treated as headers by Bnd -->
-            <_removeheaders>JAVA_1_3_HOME,JAVA_1_4_HOME,JAVA_1_5_HOME,JAVA_1_6_HOME,JAVA_1_7_HOME,JAVA_1_8_HOME,JAVA_1_9_HOME</_removeheaders>
+            <!--
+              Remove extra headers like "Bnd-LastModified" containing build-specific
+              information in order to improve reproducibility of generated JARs
+            -->
+            <_noextraheaders>true</_noextraheaders>
+            <!--
+              Stop the JAVA_1_n_HOME variables from being treated as headers by Bnd
+              Use a "merged property" as used by bndlib (see 
+              https://bnd.bndtools.org/chapters/123-tour-workspace.html) to merge these
+              variables with the default removeheaders list specified by maven-bundle-plugin
+              instead of overriding it, since the default list contains values like
+              "Include-Resource" which are important for reproducibility
+            -->
+            <_removeheaders.commons-parent>JAVA_1_3_HOME,JAVA_1_4_HOME,JAVA_1_5_HOME,JAVA_1_6_HOME,JAVA_1_7_HOME,JAVA_1_8_HOME,JAVA_1_9_HOME</_removeheaders.commons-parent>
             <Bundle-SymbolicName>${commons.osgi.symbolicName}</Bundle-SymbolicName>
             <Export-Package>${commons.osgi.export}</Export-Package>
             <Private-Package>${commons.osgi.private}</Private-Package>


### PR DESCRIPTION
[Bnd](https://github.com/bndtools/bnd)/[maven-bundle-plugin](https://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html) adds a couple of extra manifest headers like `Bnd-LastModified` recording information about the build. This makes it harder to reproduce the JAR bit for bit on a different machine. The [documented way](https://github.com/bndtools/bnd/blob/cc61fa32da6b779a9607d02b78c2052015493eb6/maven/bnd-maven-plugin/README.md#reproducible-builds) to remove these is the `-noextraheaders: true` instruction.

Even after applying this instruction, JARs still include a `Include-Resource` header, whose ordering appears to be file system dependent. It is removed in `maven-bundle-plugin` by default, but the [existing `<_removeheaders>` tag](https://github.com/apache/commons-parent/blob/b39108aba84b93b5b57b8bdc6c934fbadd98521f/pom.xml#L902) overrides
this. Use merged properties to add headers to be removed instead of replacing the list, as suggested upstream by @rotty3000 in https://github.com/bndtools/bnd/issues/4221#issuecomment-656258021.

This was originally proposed for commons-lang in https://github.com/apache/commons-lang/pull/578, also see the discussion there as well as upstream in https://github.com/bndtools/bnd/issues/4221. Since the problematic `<_removeheaders>` is in commons-parent and other commons-* projects may profit from reproducible builds as well, this seems to be the appropriate place to fix the issue.