### PR TITLE
Add CycloneDX  SBOM generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@
     <commons.compiler.version>3.10.1</commons.compiler.version>
     <commons.coveralls.version>4.3.0</commons.coveralls.version>
     <commons.coveralls.timestampFormat>EpochMillis</commons.coveralls.timestampFormat>
+    <commons.cyclonedx.version>2.7.0</commons.cyclonedx.version>
     <commons.failsafe.version>2.22.2</commons.failsafe.version>
     <commons.felix.version>5.1.6</commons.felix.version>
     <commons.findbugs.version>3.0.5</commons.findbugs.version>
@@ -815,6 +816,33 @@
             </dependency>
           </dependencies>
         </plugin>
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>${commons.cyclonedx.version}</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>makeAggregateBom</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <projectType>library</projectType>
+            <schemaVersion>1.4</schemaVersion>
+            <includeBomSerialNumber>true</includeBomSerialNumber>
+            <includeCompileScope>true</includeCompileScope>
+            <includeProvidedScope>true</includeProvidedScope>
+            <includeRuntimeScope>true</includeRuntimeScope>
+            <includeSystemScope>true</includeSystemScope>
+            <includeTestScope>false</includeTestScope>
+            <includeLicenseText>false</includeLicenseText>
+            <outputReactorProjects>true</outputReactorProjects>
+            <outputFormat>all</outputFormat>
+            <outputName>${project.artifactId}-${project.version}-bom</outputName>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -1050,6 +1078,10 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Added CycloneDX SBOM generation. CycloneDX is a OWASP Bill of Materials standard purpose-built for cybersecurity use cases. It exceeds the minimum requirements necessary to comply with EO 14028.