### PR TITLE
use makeAggregateBom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -830,22 +830,11 @@
               <id>make-bom</id>
               <phase>package</phase>
               <goals>
-                <goal>makeBom</goal>
+                <goal>makeAggregateBom</goal>
               </goals>
             </execution>
           </executions>
           <configuration>
-            <projectType>library</projectType>
-            <schemaVersion>1.4</schemaVersion>
-            <includeBomSerialNumber>true</includeBomSerialNumber>
-            <includeCompileScope>true</includeCompileScope>
-            <includeProvidedScope>true</includeProvidedScope>
-            <includeRuntimeScope>true</includeRuntimeScope>
-            <includeSystemScope>true</includeSystemScope>
-            <includeTestScope>false</includeTestScope>
-            <includeLicenseText>false</includeLicenseText>
-            <outputReactorProjects>true</outputReactorProjects>
-            <outputFormat>all</outputFormat>
             <outputName>${project.artifactId}-${project.version}-bom</outputName>
           </configuration>
         </plugin>


### PR DESCRIPTION
it has been fixed in release 2.7.4 with https://github.com/CycloneDX/cyclonedx-maven-plugin/pull/242

now it works as expected in multi-module projects: provides an aggregate BOM in the root module

while at it, I simplified configuration by using default values instead of redefining with the same content