### PR TITLE
Reuse the parent POM's maven-enforcer-plugin configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.settings/
 /target/
 /commons-parent.iml
+/.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,8 @@
   <properties>
     <!-- Minimum Maven version required by the plugins -->
     <minimalMavenBuildVersion>3.6.3</minimalMavenBuildVersion>
+    <!-- Minimum Java version required by build -->
+    <minimalJavaBuildVersion>8</minimalJavaBuildVersion>
     <!-- configuration bits for cutting a release candidate, must be overridden by components -->
     <!-- TODO How can we make project.build.outputTimestamp and changes.xml's release data the same? -->
     <project.build.outputTimestamp>2023-07-25T23:48:56Z</project.build.outputTimestamp>
@@ -151,7 +153,6 @@
     <commons.rat.version>0.15</commons.rat.version>
     <commons.release-plugin.version>1.8.1</commons.release-plugin.version>
     <commons.scm-publish.version>1.1</commons.scm-publish.version>
-    <commons.enforcer-plugin.version>3.3.0</commons.enforcer-plugin.version>
     <commons.buildnumber-plugin.version>3.2.0</commons.buildnumber-plugin.version>
     <commons.moditect-maven-plugin.version>1.0.0.Final</commons.moditect-maven-plugin.version>
     <commons.biz.aQute.bndlib.version>6.4.1</commons.biz.aQute.bndlib.version>
@@ -910,35 +911,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-      </plugin>
-      <!-- Unfortunately the much simpler
-        <prerequisites><maven>3.0</maven></prerequisites>
-        is not inherited so we have to use the enforcer plugin
-      -->
-      <plugin>
-        <inherited>true</inherited>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>${commons.enforcer-plugin.version}</version>
-        <configuration>
-          <rules>
-            <requireMavenVersion>
-              <version>${minimalMavenBuildVersion}</version>
-            </requireMavenVersion>
-            <requireJavaVersion>
-              <version>${maven.compiler.target}</version>
-            </requireJavaVersion>
-          </rules>
-          <fail>true</fail>
-        </configuration>
-        <executions>
-          <execution>
-            <id>enforce-maven-3</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -62,6 +62,7 @@ The <action> type attribute can be add,update,fix,remove.
     <body>
         <release version="60" date="2023-MM-DD" description="Version 60: Maintenance and update dependencies">
            <!-- FIX -->
+           <action type="fix" dev="sjaranowski" due-to="Slawomir Jaranowski">Reuse the parent POM's maven-enforcer-plugin configuration</action>
            <action type="fix" dev="ggregory" due-to="Gary Gregory">Workaround MSOURCES-143 by using version.maven-source-plugin 3.2.1 on Java 8.</action>
            <action type="fix" dev="ggregory" due-to="Gary Gregory">Remove property commons.source-plugin.version and reuse the parent POM's version.maven-source-plugin.</action>
            <!-- ADD -->


### PR DESCRIPTION
m-enforcer-p is configured in parent ASF pom
here we can only override properties
 - minimalMavenBuildVersion
 - minimalJavaBuildVersion

We not need to reconfigure m-enforcer-p,
even more if another executionId is used the same task is executed multiple times during build.