### PR TITLE
remove mockito from `dependencyManagement`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,6 @@
     <commons.junit.version>5.11.4</commons.junit.version>
     <!-- JUnit Pioneer 2 requires Java 11 -->
     <commons.junit-pioneer.version>1.9.1</commons.junit-pioneer.version>
-    <commons.mockito.version>4.11.0</commons.mockito.version>
     <commons.jmh.version>1.37</commons.jmh.version>
     <commons.asm.version>9.7.1</commons.asm.version>
     <commons.taglist.version>3.2.1</commons.taglist.version>
@@ -349,12 +348,6 @@
         <groupId>org.junit-pioneer</groupId>
         <artifactId>junit-pioneer</artifactId>
         <version>${commons.junit-pioneer.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockit-core</artifactId>
-        <version>${commons.mockito.version}</version>
-        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -66,7 +66,6 @@ The <action> type attribute can be add,update,fix,remove.
         <!-- ADD -->
         <action type="add" dev="ggregory" due-to="Gary Gregory">Add org.junit-pioneer:junit-pioneer to dependencyManagement.</action>
         <action type="add" dev="ggregory" due-to="Gary Gregory">Add org.apache.maven.plugins:maven-changes-plugin to pluginManagement.</action>
-        <action type="add" dev="ggregory" due-to="Arnout Engelen">Add mockito to dependencyManagement #568.</action> 
         <!-- UPDATE -->
         <action type="update" dev="sjaranowski" due-to="Slawomir Jaranowski">Update site skin and reports plugins with Doxia 2 stack.</action>
         <action type="update" dev="ggregory" due-to="Gary Gregory, Dependabot">Bump com.github.spotbugs:spotbugs-maven-plugin from 4.8.6.4 to 4.8.6.6 #518, #544.</action>


### PR DESCRIPTION
Since some Commons projects still support Java 8 and others don't, it doesn't make much sense for the parent pom to specify a version (since projects on Java 8 will want to stick with 4.x while others will want to move to 5.x)

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that commits might be squashed by a maintainer on merge.
