### PR TITLE
Remove -nouses directive from maven-bundle-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -970,8 +970,6 @@
           <excludeDependencies>${commons.osgi.excludeDependencies}</excludeDependencies>
           <manifestLocation>${project.build.directory}/osgi</manifestLocation>
           <instructions>
-            <!-- stops the "uses" clauses being added to "Export-Package" manifest entry -->
-            <_nouses>true</_nouses>
             <!-- Stop the JAVA_1_n_HOME variables from being treated as headers by Bnd -->
             <_removeheaders>JAVA_1_3_HOME,JAVA_1_4_HOME,JAVA_1_5_HOME,JAVA_1_6_HOME,JAVA_1_7_HOME,JAVA_1_8_HOME,JAVA_1_9_HOME</_removeheaders>
             <Bundle-SymbolicName>${commons.osgi.symbolicName}</Bundle-SymbolicName>


### PR DESCRIPTION
In commit 740bcf1e180f15931bdc09a27dd2a7f087844671 the instruction '-nouses' was added (but without any rationale) but using that is extremely dangerous. Without any use clause, all packages are treated as independent from each other, that means the OSGi resolver is free to wire these packages to different classloaders if used by a consumer (or its dependencies).

This now completely removes the offending clause from the instructions, if any project has a real usecase for this (even though I can't think of cases it would be useful) they still can enable it on their demands.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [ ] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body. Note that commits might be squashed by a maintainer on merge.
