### PR TITLE
feat: Add reusable `codeql-analysis-reusable.yml` workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,7 +37,7 @@ ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
 
 | Input       | Type   | Default                 | Description                                                                                                                                                                          |
 |-------------|--------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `languages` | string | `"['actions', 'java']"` | JSON array of [CodeQL language identifiers](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-language-support) to analyze. |
+| `languages` | string | `"["actions", "java"]"` | JSON array of [CodeQL language identifiers](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-language-support) to analyze. |
 
 ### Required permissions
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,76 @@
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+# Reusable Workflows
+
+This directory contains
+[reusable GitHub Actions workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)
+shared across Apache Commons projects. They provide a consistent and secure CI setup without duplicating configuration in each repository.
+
+## CodeQL (`codeql-analysis-reusable.yml`)
+
+Runs a [CodeQL](https://codeql.github.com/) security analysis and uploads the results to GitHub's
+code-scanning dashboard. A separate job is created for each analyzed language.
+
+To speed up the Java autobuild step, the workflow tries to restore a Maven dependency cache saved by
+a prior build job. For the cache to be found, the build workflow must store it under the key:
+
+```
+${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+```
+
+### Inputs
+
+| Input       | Type   | Default                 | Description                                                                                                                                                                          |
+|-------------|--------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `languages` | string | `"['actions', 'java']"` | JSON array of [CodeQL language identifiers](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-language-support) to analyze. |
+
+### Required permissions
+
+The caller job must grant:
+
+```yaml
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+```
+
+### Usage example
+
+```yaml
+name: CodeQL
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request: { }
+  schedule:
+    - cron: '33 9 * * 4'   # Randomize this expression
+
+# Explicitly drop all permissions for security.
+permissions: { }
+
+jobs:
+  codeql:
+    # Intentionally not pinned: maintained by the same PMC.
+    uses: apache/commons-parent/.github/workflows/codeql-analysis-reusable.yml@master
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+```

--- a/.github/workflows/codeql-analysis-reusable.yml
+++ b/.github/workflows/codeql-analysis-reusable.yml
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CodeQL (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      languages:
+        type: string
+        description: Languages to analyze
+        default: "['actions', 'java']"
+        required: true
+
+# Explicitly drop all permissions inherited from the caller for security.
+permissions: { }
+
+jobs:
+
+  codeql-analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{ fromJSON(inputs.languages) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # If available, restore the cache created by a build job
+      - name: Restore Maven cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  #v5.0.5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.github/workflows/codeql-analysis-reusable.yml
+++ b/.github/workflows/codeql-analysis-reusable.yml
@@ -21,7 +21,7 @@ on:
       languages:
         type: string
         description: Languages to analyze
-        default: "['actions', 'java']"
+        default: '["actions", "java"]'
         required: true
 
 # Explicitly drop all permissions inherited from the caller for security.

--- a/.github/workflows/codeql-analysis-reusable.yml
+++ b/.github/workflows/codeql-analysis-reusable.yml
@@ -22,7 +22,6 @@ on:
         type: string
         description: Languages to analyze
         default: '["actions", "java"]'
-        required: true
 
 # Explicitly drop all permissions inherited from the caller for security.
 permissions: { }

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ permissions: { }
 
 jobs:
   codeql-analysis:
-    # Differs from documentation, since this allows to test the workflow in PRs
+    # Differs from documentation, since this allows testing the workflow in PRs
     uses: ./.github/workflows/codeql-analysis-reusable.yml
     permissions:
       actions: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,68 +19,18 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ master ]
   schedule:
     - cron: '33 9 * * 4'
 
-permissions:
-  contents: read
+# Explicitly drop all permissions for security.
+permissions: { }
 
 jobs:
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
+  codeql-analysis:
+    # Differs from documentation, since this allows to test the workflow in PRs
+    uses: ./.github/workflows/codeql-analysis-reusable.yml
     permissions:
       actions: read
       contents: read
       security-events: write
-
-    strategy:
-      max-parallel: 20
-      fail-fast: false
-      matrix:
-        language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        persist-credentials: false
-    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  #v5.0.5
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,3 +34,6 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    # This repository does not contain any Java code
+    with:
+      languages: '["actions"]'


### PR DESCRIPTION
Adds a reusable CodeQL analysis workflow and refactors `codeql-analysis.yml` to call it instead of running the analysis inline.

Centralizing the workflow in `commons-parent` means dependency upgrades (e.g. `codeql-action`) only need to be done once for all repositories. Referencing the `master` branch is safe because the same PMC controls both `commons-parent` and the other `commons-*` repositories.
