### PR TITLE
fix: dependency management scope for `mockito-bom`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,8 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-bom</artifactId>
         <version>${commons.mockito.version}</version>
-        <scope>test</scope>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
The `mockito-bom` artifact didn't have an `import` scope, so it was managed as an artifact instead of importing its dependencies.
