### PR TITLE
Bump org.apache.maven.plugins:maven-source-plugin from 3.2.1 to 3.4.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,7 @@
     <commons.compiler.compilerVersion />
     <commons.compiler.javac />
     <commons.compiler.javadoc />
-    <!-- https://issues.apache.org/jira/projects/MSOURCES/issues/MSOURCES-143 -->
-    <version.maven-source-plugin>3.2.1</version.maven-source-plugin>
+    <version.maven-source-plugin>3.4.0</version.maven-source-plugin>
     <!-- plugin versions (allows same value in reporting and build sections; also allows easy override) -->
     <commons.animal-sniffer.version>1.27</commons.animal-sniffer.version>
     <!-- Almost all signatures use version 1.0. Allow override just in case -->
@@ -911,7 +910,7 @@
         <artifactId>maven-source-plugin</artifactId>
         <executions>
           <execution>
-            <id>create-source-jar</id>
+            <id>attach-sources</id>
             <goals>
               <goal>jar-no-fork</goal>
               <goal>test-jar-no-fork</goal>
@@ -1533,18 +1532,6 @@
             <configuration>
               <releaseProfiles>apache-release</releaseProfiles>
             </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-test-sources</id>
-                <goals>
-                  <goal>test-jar</goal>
-                </goals>
-              </execution>
-            </executions>
           </plugin>
           <plugin>
             <artifactId>maven-install-plugin</artifactId>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -59,9 +59,10 @@ The <action> type attribute can be add,update,fix,remove.
     <body>
       <release version="100" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
         <!-- FIX -->
-		<action type="fix" dev="ggregory" due-to="Slawomir Jaranowski">Remove redundant manifest entries for javadoc and source plugins, now inherited from org.apache:parent:36 #703.</action>
+        <action type="fix" dev="ggregory" due-to="Slawomir Jaranowski">Remove redundant manifest entries for javadoc and source plugins, now inherited from org.apache:parent:36 #703.</action>
         <!-- ADD -->
         <!-- UPDATE -->
+        <action type="update" dev="sjaranowski" due-to="Slawomir Jaranowski">Bump org.apache.maven.plugins:maven-source-plugin from 3.2.1 to 3.4.0.</action>
       </release>
       <release version="99" date="2026-04-19" description="This is a feature and maintenance release. Java 8 or later is required.">
         <!-- FIX -->


### PR DESCRIPTION
What changed:
- Updated `version.maven-source-plugin` from 3.2.1 to 3.4.0.

- Use the same name for execution as is in parent to allow add next goal to existing execution without trigger the same build twice

- Removed plugin execution from apache-release profile - it will trigger second build of the same artifact

This resolves a problem reported in issue:
- https://github.com/apache/maven-source-plugin/issues/205

---

I have tested on `commons-validator` with profiles `release` - commons custom and `apache-release` from ASF parent

---

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
