### PR TITLE
Add GitHub Rulesets via `.asf.yaml`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -46,7 +46,6 @@ notifications:
         branches:
           includes:
             - "~DEFAULT_BRANCH"
-            - "release"
       # Use raw rules, until a convenience notation for `restrict_update` is introduced.
       # See: https://github.com/apache/infrastructure-asfyaml/issues/96
       #

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -52,10 +52,14 @@ notifications:
       # The raw rules need to follow the syntax given in:
       # https://docs.github.com/en/rest/repos/rules?apiVersion=2026-03-10#update-a-repository-ruleset
       - name: "Tag protection"
-        type: tag
-        branches:
-          includes:
-            - "rel/*"
+        target: tag
+        enforcement: active
+        bypass_actors: []
+        conditions:
+          ref_name:
+            include:
+              - "refs/tags/rel/*"
+            exclude: []
         rules:
           - type: deletion
           - type: non_fast_forward

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -13,13 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
-# Additional non-standard features
-#
-meta:
-  environments:
-    - github_rulesets
-
 github:
   description: "Apache Commons Parent"
   homepage: https://commons.apache.org/parent/

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -13,6 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# Additional non-standard features
+#
+meta:
+  environments:
+    - github_rulesets
+
 github:
   description: "Apache Commons Parent"
   homepage: https://commons.apache.org/parent/
@@ -28,3 +35,29 @@ notifications:
     pullrequests_bot_dependabot: dependabot@commons.apache.org
     issues_bot_codecov-commenter: notifications@commons.apache.org
     pullrequests_bot_codecov-commenter: notifications@commons.apache.org
+
+  # Clear Protected Branches configuration: it is replaced by GitHub Rulesets
+    protected_branches: ~
+
+    rulesets:
+      # Use minimum level of protection: restrict deletion and force pushes.
+      - name: "Branch protection"
+        type: branch
+        branches:
+          includes:
+            - "~DEFAULT_BRANCH"
+            - "release"
+      # Use raw rules, until a convenience notation for `restrict_update` is introduced.
+      # See: https://github.com/apache/infrastructure-asfyaml/issues/96
+      #
+      # The raw rules need to follow the syntax given in:
+      # https://docs.github.com/en/rest/repos/rules?apiVersion=2026-03-10#update-a-repository-ruleset
+      - name: "Tag protection"
+        type: tag
+        branches:
+          includes:
+            - "rel/*"
+        rules:
+          - type: deletion
+          - type: non_fast_forward
+          - type: update


### PR DESCRIPTION
Configure a minimal Ruleset to:

- Prevent deletion and force-push on the default (`master`) branch and the `release` branch.
- Prevent deletion, force-push, or update of any `rel/*` tag.

Together, these rules satisfy the Tier 1 protection level defined by [Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection) and should allow for [SLSA Source L3](https://slsa.dev/spec/v1.2/source-requirements#source-l3) compliance, once we introduce a workflow to push provenance attestation at each commit.
