### PR TITLE
Add SLSA Source Provenance workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -74,3 +74,54 @@ jobs:
       contents: read
       security-events: write
 ```
+
+## SLSA Source Provenance (`slsa-provenance-reusable.yml`)
+
+Generates a [SLSA Source Provenance](https://slsa.dev/spec/v1.2/source-requirements) attestation
+for the triggering commit using
+[`slsa-framework/source-actions`](https://github.com/slsa-framework/source-actions), signs it via
+Sigstore (OIDC), and stores the result in Git Notes. Merge commits are supported.
+
+Combined with the branch and tag protection rules configured in `.asf.yaml`, this workflow
+contributes to [SLSA Source L3](https://slsa.dev/spec/v1.2/source-requirements#source-l3)
+compliance.
+
+### Required permissions
+
+The caller job must grant:
+
+```yaml
+permissions:
+  # Store attestations in the repo
+  contents: write
+  # Get a Sigstore certificate via OIDC
+  id-token: write
+```
+
+### Usage example
+
+The workflow should run on every push to a protected branch or tag, so that the attestation
+covers the same refs whose history is being protected:
+
+```yaml
+name: SLSA Source Provenance
+
+on:
+  push:
+    branches:
+      - master
+      - release
+    tags:
+      - 'rel/*'
+
+# Explicitly drop all permissions for security.
+permissions: { }
+
+jobs:
+  slsa-source-provenance:
+    # Intentionally not pinned: maintained by the same PMC.
+    uses: apache/commons-parent/.github/workflows/slsa-provenance-reusable.yml@master
+    permissions:
+      contents: write
+      id-token: write
+```

--- a/.github/workflows/slsa-provenance-reusable.yml
+++ b/.github/workflows/slsa-provenance-reusable.yml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: SLSA Source Provenance (reusable)
+
+on:
+  workflow_call:
+
+# Explicitly drop all permissions inherited from the caller for security.
+permissions: { }
+
+jobs:
+
+  slsa-source-provenance:
+    runs-on: ubuntu-latest
+    permissions:
+      # Store attestations in the repo
+      contents: write
+      # Get a Sigstore certificate via OIDC
+      id-token: write
+
+    steps:
+      # Generates a SLSA Provenance attestation for the commit and stores the result in Git Notes
+      - name: Generate SLSA Source Provenance
+        uses: slsa-framework/source-actions/slsa_with_provenance@dea965cdca5e0cb422bf7b2653c9d15f678ad01c # v0.1.0
+        with:
+          allow-merge-commits: true
+          version: v0.6.2

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: SLSA Source Provenance
+
+on:
+  push:
+    branches:
+      - master
+      - release
+    tags:
+      - 'rel/*'
+
+# Explicitly drop all permissions for security.
+permissions: { }
+
+jobs:
+  slsa-source-provenance:
+    # Differs from documentation, since this allows testing the workflow in PRs
+    uses: ./.github/workflows/slsa-provenance-reusable.yml
+    permissions:
+      contents: write
+      id-token: write


### PR DESCRIPTION
Add a reusable workflow that generates a [SLSA Source Provenance](https://slsa.dev/spec/v1.2/source-requirements) attestation for the triggering commit, and a caller that wires it up for this repository:

- `slsa-provenance-reusable.yml`: signs a SLSA Provenance attestation for the commit via Sigstore (OIDC) and stores the attestation in Git Notes using [`slsa-framework/source-actions`](https://github.com/slsa-framework/source-actions). Merge commits are supported.
- `slsa-provenance.yml`: runs the reusable workflow on every push to a protected named reference (`master`, `release`, `rel/*`).

Combined with the branch and tag protection rules introduced in #705, this contributes to [SLSA Source L3](https://slsa.dev/spec/v1.2/source-requirements#source-l3) compliance. The reusable workflow is also documented in `.github/workflows/README.md`.

> [!NOTE]
> This PR should be evaluated once the protection rules introduced in #705 are enabled.
