### PR TITLE
Ignore JUnit 6.x upgrade proposals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,11 @@ updates:
     directory: "/"
     schedule:
       interval: "quarterly"
+    ignore:
+      # JUnit 6.x requires Java 17
+      - dependency-name: "org.junit:*"
+        versions: [ "[6,)" ]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Changes the Dependabot configuration, to ignore JUnit 6 upgrade proposals. JUnit 6 requires Java 17 and most of the projects have a Java 8 baseline.
